### PR TITLE
Add explicit type conversions for numpy2 compatibility

### DIFF
--- a/grad_board.py
+++ b/grad_board.py
@@ -491,7 +491,7 @@ class GPAFHDO:
             grad_vals_cal = self.apply_cal(grad_vals, channel)
         else:
             grad_vals_cal = grad_vals
-        gr_dacbits = np.round(32767.51 * (grad_vals_cal + 1)).astype(np.uint16)
+        gr_dacbits = np.round(32767.51 * (grad_vals_cal + 1)).astype(np.uint32)
         gr = gr_dacbits | 0x80000 | (channel << 16)
 
         # # always broadcast for the final channel (TODO: probably not needed for GPA-FHDO, check then remove)

--- a/marcompile.py
+++ b/marcompile.py
@@ -9,9 +9,6 @@ try:
 except ModuleNotFoundError:
     grad_board = "gpa-fhdo"
 
-import pdb
-st = pdb.set_trace
-
 grad_data_bufs = (1, 2)
 
 max_removed_instructions = 1000
@@ -22,7 +19,7 @@ def debug_print(*args, **kwargs):
 
 def col2buf(col_idx, value):
     """ Returns a tuple of (buffer indices), (values), (value masks)
-    A value masks specifies which bits are actually relevant on the output.
+    Value masks specify which bits are actually relevant on the output.
     Can accept arrays of values."""
     if col_idx in (1, 2, 3, 4): # TX
         buf_idx = col_idx + 4, # TX0_I, TX0_Q, TX1_I, TX1_Q
@@ -91,7 +88,7 @@ def col2buf(col_idx, value):
         val = value << bit_idx,
         mask = 0x0003 << bit_idx,
 
-    return buf_idx, val, mask
+    return np.uint16(buf_idx), np.uint16(val), np.uint16(mask)
 
 def csv2bin(path, quick_start=False, initial_bufs=np.zeros(MARGA_BUFS, dtype=np.uint16), latencies = np.zeros(MARGA_BUFS, dtype=np.int32)):
     """ initial_bufs: starting state of output buffers, to track with instructions
@@ -228,7 +225,7 @@ def cl2bin(changelist, changelist_grad,
                 if msb:
                     if num_chgs[1]: # MSB buffer and not the first grad event on this timestep
                         # turn broadcast off if this isn't the first grad event on this timestep
-                        data = data & ~0x0100
+                        data = data & ~np.uint16(0x0100)
                         # return LSB back to old values, since this one is now done in the past
                         grad_vals[:] = grad_vals_old # revert the last known buffer values
                 # else:
@@ -314,8 +311,8 @@ def cl2bin(changelist, changelist_grad,
     for ch, ch_prev in zip( reversed(changes[1:]), reversed(changes[:-1]) ):
         # does the current timestep need to output more data than can
         # fit into the time gap since the previous timestep?
-        timestep = ch[0] - ch_prev[0]
-        timediff = ch[1].size - timestep
+        timestep = np.int32(ch[0] - ch_prev[0])
+        timediff = np.int32(ch[1].size - timestep)
         # if timestep < ch[1].size: # not enough time
 
         if timediff > 0:
@@ -383,7 +380,7 @@ def cl2bin(changelist, changelist_grad,
         for m, (ind, dat) in enumerate(zip(event[1], event[2])):
             execution_delay = b_instrs - m - 1 #+ time - 2
             btli = buf_time_left[ind]
-            buf_empty = btli <= m # or <= m, need to check
+            buf_empty = btli <= m
             if buf_empty: # buffer empty for this instruction; need an appropriate delay only for sync
                 # (check against m since with successive cycles, remaining buffers will empty out)
                 extra_delay = execution_delay + this_time_offset

--- a/marmachine.py
+++ b/marmachine.py
@@ -4,6 +4,8 @@
 # Functions should be fast, without any floating-point arithmetic -
 # that should be handled at a higher level.
 
+import numpy as np
+
 class MarUserWarning(UserWarning):
     pass
 
@@ -60,15 +62,15 @@ CIC_STAGES = 6 # N: number of CIC stages in the RX CICs
 CIC_RATE_DATAWIDTH = 12 # 12-bit rate/data bus, 2-bit address
 CIC_FASTEST_RATE, CIC_SLOWEST_RATE = 4, 4095 # CIC core settings
 
-def insta(instr, data):
+def insta(instr: np.uint8, data: np.uint32):
     """ Instruction A: FSM control """
     assert instr in [INOP, IFINISH, IWAIT, ITRIG, ITRIGFOREVER], "Unknown instruction"
     assert (data & COUNTER_MAX) == (data & 0xffffffff), "Data out of range"
     return (instr << 24) | (data & 0xffffff)
 
-def instb(tgt, delay, data):
+def instb(tgt: np.uint8, delay: np.uint8, data: np.uint16):
     """ Instruction B: timed buffered data """
     assert tgt <= 24, "Unknown target buffer"
     assert 0 <= delay <= 255, "Delay out of range"
-    assert (data & 0xffff) == (data & 0xffffffff), "Data out of range"
-    return (IDATA << 24) | ( (tgt & 0x7f) << 24 ) | ( (delay & 0xff) << 16 ) | (data & 0xffff)
+    assert (np.uint32(data) & 0xffff) == (np.uint32(data) & 0xffffffff), "Data out of range"
+    return (IDATA << 24) | ( (tgt & 0x7f) << 24 ) | (delay << 16) | np.uint32(data)


### PR DESCRIPTION
Numpy 2 changes the way certain type conversions are implicitly handled, and is stricter about overflows - see https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion and https://numpy.org/neps/nep-0050-scalar-promotion.html#nep50 for detailed info.

As far as MaRCoS is affected, the compiler uses a lot of fixed-width signed and unsigned integers implicitly in some fairly involved logic operations. I've added various casts and conversions to fix the bugs that arose with Numpy 2, however others may remain undetected until specific value ranges are hit in the input data.

@josalggui, @catkira please let me know if these changes cause you any issues/problems in your workflows.