### PR TITLE
Add pyproject.toml to make this a Python package. Resolves #12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "marcos_client"
+version = "0.1.0"
+description = "Client (GUI and command-line interfaces) for MaRCoS"
+readme = { file = "readme.org", content-type = "text/plain" }
+authors = [{ name = "Vlad Negnevitsky" }]
+license = { text = "GPL-3.0-or-later" }
+requires-python = ">=3.7"
+dependencies = ["numpy", "matplotlib", "msgpack"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]  # Because the repo is "flat", i.e. the source code is not in a "marcos_client" subfolder


### PR DESCRIPTION
This has the advantage that the package can be installed with pip, hatch, poetry, and any other package management software. This will also automatically install the `numpy`, `matplotlib` and `msgpack` dependencies.

Instead of manually cloning the repository, one can now simply use pip to install the package. The modules will be placed inside `site-packages` exactly as they are found in the repo. Everything else works just as described in the wiki/in the tutorials. This doesn't change the current behavior and/or usage of the code.

For example, to install `marcos_client` in the current environment (as soon as this PR is merged):

```console
pip install git+https://github.com/vnegnev/marcos_client.git
```

In a project, you need to create the `local_config.py` and then simply write your own sequence e.g. in `my_sequence.py`. There you'd for example `import experiment as ex`, as is done in the tutorials. Resulting folder structure:
```
my_project/
  __init__.py
  my_sequence.py
  local_config.py
```

This is, I think, the simplest change to make it into a Python package. From here, one could go further and upload it to [pypi](pypi.org), make it a self-contained package with a CLI, a test suite, etc. Breaking changes can also be communicated and managed more easily, as this introduces a version that can be pinned by users.

Let me know what you think!